### PR TITLE
shellhub-agent: Add shadow to RDEPENDS

### DIFF
--- a/recipes-core/shellhub/shellhub-agent_0.6.0.bb
+++ b/recipes-core/shellhub/shellhub-agent_0.6.0.bb
@@ -56,6 +56,7 @@ do_install_append() {
 RDEPENDS_${PN} += "\
     openssh-scp \
     shellhub-agent-config \
+    shadow \
 "
 
 RRECOMMENDS_${PN} += "ca-certificates"


### PR DESCRIPTION
ShellHub uses shadow for authentication, add shadow as
runtime dependency to ensure that shadow is installed on the image.

Signed-off-by: Vinicius Aquino <voa.aquino@gmail.com>