### PR TITLE
shellhub-agent: Allow the execution of scripts before start the service

### DIFF
--- a/recipes-core/shellhub/shellhub-agent/shellhub-agent.wrapper.in
+++ b/recipes-core/shellhub/shellhub-agent/shellhub-agent.wrapper.in
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+for i in /etc/shellhub-agent.environment.d/*.sh ; do
+    [ -r "$i" ] && . $i
+done
+
+@LIBEXEC@/shellhub/bin/shellhub-agent $@

--- a/recipes-core/shellhub/shellhub-agent_0.7.2.bb
+++ b/recipes-core/shellhub/shellhub-agent_0.7.2.bb
@@ -10,6 +10,7 @@ SRC_URI = " \
     file://shellhub-agent.profile.d \
     file://shellhub-agent.service \
     file://shellhub-agent.start \
+    file://shellhub-agent.wrapper.in \
 "
 
 inherit go systemd update-rc.d
@@ -34,7 +35,8 @@ do_compile[dirs] += "${B}/src/${GO_IMPORT}/agent"
 
 do_install:append() {
     # We name the binary as shellhub-agent
-    mv ${D}${bindir}/agent ${D}${bindir}/shellhub-agent
+    mkdir -p ${D}${libexecdir}/shellhub/bin/
+    mv ${D}${bindir}/agent ${D}${libexecdir}/shellhub/bin/shellhub-agent
 
     # Handle init system integration
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
@@ -53,6 +55,10 @@ do_install:append() {
 
     # Shell prompt handling
     install -Dm 0755 ${WORKDIR}/shellhub-agent.profile.d ${D}/${sysconfdir}/profile.d/shellhub-agent.sh
+
+    # Script that allow to run sh files before shellhub-agent binary start
+    install -Dm 0755 ${WORKDIR}/shellhub-agent.wrapper.in ${D}${bindir}/shellhub-agent
+    sed -e 's,@LIBEXEC@,${libexecdir},g' -i ${D}${bindir}/shellhub-agent
 }
 
 RDEPENDS:${PN} += "\


### PR DESCRIPTION
Now, instead of start the shellhub-agent binary immediatally, the service first
runs a script wich runs *.sh files in /etc/shellhub-agent.environment.d/.
The intention is to make possible to export variables so that they can be used
by the shellhub-agent binary, regardless the service manager adopted.

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>