### PR TITLE
shellhub-agent: Bump revision to ad85eb58

### DIFF
--- a/recipes-core/shellhub/shellhub-agent_0.9.1.bb
+++ b/recipes-core/shellhub/shellhub-agent_0.9.1.bb
@@ -5,13 +5,15 @@ LIC_FILES_CHKSUM = "file://${S}/src/${GO_IMPORT}/LICENSE.md;md5=fa818a259cbed7ce
 DEPENDS = "libxcrypt"
 
 SRC_URI = " \
-    git://github.com/shellhub-io/shellhub;protocol=https;nobranch=1;tag=v${PV} \
+    git://github.com/shellhub-io/shellhub;protocol=https;branch=master \
     file://shellhub-agent.initd \
     file://shellhub-agent.profile.d \
     file://shellhub-agent.service \
     file://shellhub-agent.start \
     file://shellhub-agent.wrapper.in \
 "
+
+SRCREV = "ad85eb5800d611dc72c28928704b143b0adc3eac"
 
 inherit go systemd update-rc.d
 


### PR DESCRIPTION
This commit includes the following changes:

    - ad85eb58 pkg: add jwt middleware
    - d12fc5e0 Bump shellhub version to 0.9.1-rc.5
    - 0350f6a5 ui: fix empty name in page refresh
    - f16121ab Bump shellhub version to 0.9.1-rc.4
    - 3c0e49bd ui: fix default value of tagChoices
    - 4a091156 pkg: update retrial condition to include network errors
    - 134e86f4 ui: bump @fortawesome/free-solid-svg-icons from 6.0.0 to 6.1.0 in /ui
    - ef6a1861 api: bump github.com/stretchr/testify from 1.7.0 to 1.7.1 in /api
    - 83d00ddd api: bump github.com/go-redis/redis/v8 from 8.11.4 to 8.11.5 in /api
    - 79d1aa62 api: bump github.com/labstack/echo/v4 from 4.7.1 to 4.7.2 in /api
    - a2370c34 ui: bump @vue/cli-plugin-unit-jest from 4.5.15 to 4.5.16 in /ui
    - 358869c7 ui: bump @fortawesome/free-brands-svg-icons from 6.0.0 to 6.1.0 in /ui
    - b96a1507 ui: bump vue-cli-plugin-vuetify from 2.4.7 to 2.4.8 in /ui
    - b568efd0 ui: bump @vue/cli-plugin-babel from 5.0.1 to 5.0.3 in /ui
    - 457945b7 agent: bump github.com/stretchr/testify from 1.7.0 to 1.7.1 in /agent
    - 152ac327 gomod: tidify gomod files
    - aaddf829 api: bump github.com/golang-jwt/jwt/v4 from 4.3.0 to 4.4.0 in /api
    - 0a47fd37 cli: bump github.com/stretchr/testify from 1.7.0 to 1.7.1 in /cli
    - e246596b docker: api: bump alpine from 3.15.0 to 3.15.1 in /api
    - 06e62f54 docker: cli: bump golang in /cli
    - 4f240888 docker: cli: bump alpine from 3.15.0 to 3.15.1 in /cli
    - 1900a6eb docker: ssh: bump alpine from 3.15.0 to 3.15.1 in /ssh
    - e4e70be1 docker: agent: bump arm32v6/golang in /agent
    - b991186a docker: agent: bump arm64v8/golang in /agent
    - b9cb0af6 docker: agent: bump arm32v7/golang in /agent
    - a18d5b6a docker: agent: bump golang in /agent
    - 78459a2c docker: ssh: bump golang in /ssh
    - 022ea43e docker: agent: bump alpine from 3.15.0 to 3.15.1 in /agent
    - b9f1817f docker: api: bump golang in /api
    - 2c05934d Bump shellhub version to 0.9.1-rc.3
    - 0e41eb07 ui: Add tag feature to the firewall rules dialog
    - 88ea5be3 api, pkg, openapi: add tags to firewall rules
    - cf7ab37a ui: fix namespace auto switch
    - 9593077b ui: add small fixes
    - 2167a1c9 ui: bump vuetify from 2.6.3 to 2.6.4 in /ui
    - d7cdd08c gomod: tidify gomod files
    - 77c529b1 api: bump github.com/spf13/cobra from 1.3.0 to 1.4.0 in /api
    - 6e808e54 gomod: tidify gomod files
    - d1ed4c20 api: bump github.com/go-playground/validator/v10 in /api
    - cb4353b3 cli: bump github.com/spf13/cobra from 1.3.0 to 1.4.0 in /cli
    - b2bbe699 gomod: tidify gomod files
    - f5b019d4 api: bump github.com/labstack/echo/v4 from 4.7.0 to 4.7.1 in /api
    - 6febebd2 agent: bump github.com/docker/docker in /agent
    - 640c8d0a agent: bump github.com/spf13/cobra from 1.3.0 to 1.4.0 in /agent
    - 5d1e1acb ui: bump axios from 0.26.0 to 0.26.1 in /ui
    - e1456931 api: change how public_key is merged when migration 42 is down
    - afaee0c1 api: fix down on migration 42
    - f774c3c1 api: fix database selection
    - 43808e0b mongo: set replicaset hostname to the same as container hostname
    - 2a8a81c4 api: pass database name using Mongo connection string URI
    - bbfd88b9 cli: pass database name using Mongo connection string URI
    - 3beb23b7 ssh: bump github.com/pires/go-proxyproto from 0.6.1 to 0.6.2 in /ssh
    - 328aed69 gomod: tidify gomod files
    - 2888c9cd api: bump go.mongodb.org/mongo-driver from 1.8.3 to 1.8.4 in /api
    - 9d4deb58 docker: ssh: bump golang in /ssh
    - d7e40f21 docker: cli: bump golang in /cli
    - b8e57a29 api: add transaction for tags and test when it isn't a replica set
    - e1949b13 ui: bump xterm from 4.17.0 to 4.18.0 in /ui
    - ab894377 ui: bump @vue-stripe/vue-stripe from 4.4.1 to 4.4.2 in /ui
    - d011569a ui: bump vue-cli-plugin-vuetify from 2.4.6 to 2.4.7 in /ui
    - e95426ed gomod: tidify gomod files
    - 2795cb92 api: bump github.com/labstack/echo/v4 from 4.6.3 to 4.7.0 in /api
    - 35a1659a cli: bump go.mongodb.org/mongo-driver from 1.8.3 to 1.8.4 in /cli
    - 8a1dc5b2 docker: agent: bump golang in /agent
    - 8d4ff7db docker: api: bump golang in /api
    - 8815350f docker: agent: bump arm32v6/golang in /agent
    - aff251db docker: agent: bump arm64v8/golang in /agent
    - c83022bc docker: agent: bump arm32v7/golang in /agent
    - ec8058a2 dbtest: add option to initialize dbtest as a replica set.
    - 48e8c60a dbtest: run a replicaset instance instead of standalone mongo instance
    - e5c676f9 docker: convert standalone mongodb instance to local replicaset
    - a713c0ef ui: split tags api call into its own file
    - b6b1f608 api: split common tag functions to it own flow
    - e4d78a66 openapi: change route to get, rename and delete tags
    - 9170bf80 bin: ensure EXTRA_COMPOSE_FILE exists
    - b91f5c1d ui: bump eslint-plugin-vue from 8.4.1 to 8.5.0 in /ui
    - 4822f769 ui: bump sass from 1.49.8 to 1.49.9 in /ui
    - b0a183d1 ui: bump vue-cli-plugin-vuetify from 2.4.5 to 2.4.6 in /ui
    - 46224061 ui: bump url-parse from 1.5.7 to 1.5.10 in /ui
    - 2a792e0f api: add sort function to guarantee tags order on test
    - 1af87bec general: prepare v0.9.1-rc.2
    - ae85f239 ui: standardize dialog size when add public key
    - 1ac9b30c api: fix inverse filter evaluation and add tests to it
    - 755a7b4f ui: update public key form to choose filtering
    - c341f8b3 api: fix public key loop with wrong range definition
    - 67294ab9 api: remove local lambda function to find tag to use contains function
    - 6b874825 api: add helper indicator to tests on public key store tests
    - e97cb7ba api: block request when hostname is empty or tags is empty
    - f8c7d449 api, pkg: add permissions and permission check to ssh key tags
    - 4f4e56a8 api: add filter evaluation instead of only hostname
    - 422869b1 api: add an error return when the public key doesn't have tags
    - 16a5c8ab api: remove public key validation from store in favor of service
    - 78c8efaf api: add queries to get device and public key tags
    - f7b1addc api: add store method to delete a tag from all public keys
    - 5eae0f3a api: add method on store to rename a public key tag when device rename it
    - 33651598 api: add route, service and store method to update the public keys tags field
    - 420d71cb api: add route, service and store method to remove a tag from public keys
    - 19063c21 api: add routes, services and store methods to add tags on public keys
    - 438dbfca api: add migration to change public key hostname to filter hostname
    - 61acc76d pkg: add tags field to public key's model
    - 55e0fdec openapi: add documentation to public keys tag routes
    - 0fab9ea7 api: add documentation to namespace's services
    - 21bda04a ui: fix device rename permission in device details
    - b8c089e0 ui: fix device delete permission in device details
    - 201a5727 ui: remove unused files after refactoring components
    - 256ab3f0 ui: ui: create unique component only for private key editing
    - 9d59e4b0 ui: create unique component only for private key adding
    - 5fc23ac5 ui: create unique component only for private key deleting
    - c41912f7 ui: add dispatches in namespace and tags components
    - 5196b22c github: ignore major update dependency cli plugin unit jest
    - 57cc4d27 github: ignore major update dependency cli-service
    - 352f82d5 ui: bump @vue/cli-plugin-babel from 4.5.15 to 5.0.1 in /ui
    - 959b619b ui: refactor the component session close record
    - 026fe10b ui: refactor the component session record delete
    - 40827430 ui: refactor the component play session
    - d3a90d4a ui: refactor the component device rename
    - 5af06105 ui: bump shelljs from 0.8.4 to 0.8.5 in /ui
    - 68777b6a ui: bump sass from 1.49.7 to 1.49.8 in /ui
    - af7f3b38 ui: bump core-js from 3.21.0 to 3.21.1 in /ui
    - db41d1c1 ui: bump timezone-mock from 1.3.0 to 1.3.1 in /ui
    - 5d12b2eb ui: refactor the component device delete
    - 384ad5ab ui: create unique component only for tag editing
    - 4487c9be ui: refactor the component tag update
    - b476e9e7 ui: bump url-parse from 1.5.3 to 1.5.7 in /ui
    - 79ad5583 api: update validator to v10
    - c7abaf7d ui:  refactor the component tag delete
    - 13e3861c ui: create unique component only for public key editing
    - 87b2172d ui: refactor the component firewall rule delete
    - 47d5d087 ui: create unique component only for public key deletion
    - 9bfbd49d ui: fix variable name used to add the firewall
    - 8a73edab ui: fix rule in validation provider
    - b0d3a87b ui: create component to edit public key
    - 2eabcd2a ui: bump @fortawesome/fontawesome-svg-core from 1.2.36 to 1.3.0 in /ui
    - 2421a76b gomod: tidify gomod files
    - 81fb61a3 api: bump github.com/golang-jwt/jwt/v4 from 4.2.0 to 4.3.0 in /api
    - 2881501a ui: bump axios from 0.25.0 to 0.26.0 in /ui
    - 488eefc6 ui: bump @fortawesome/free-solid-svg-icons from 5.15.4 to 6.0.0 in /ui
    - cce877f0 ui: bump @fortawesome/free-brands-svg-icons from 5.15.4 to 6.0.0 in /ui
    - 5b23e826 docker: api: bump golang in /api
    - fd2a743f docker: agent: bump golang in /agent
    - c4929b10 docker: cli: bump golang in /cli
    - ffc1e5a2 docker: ssh: bump golang in /ssh
    - 4d8b245d docker: agent: bump arm32v7/golang in /agent
    - adde95c2 docker: agent: bump arm64v8/golang in /agent
    - f3230855 docker: agent: bump arm32v6/golang in /agent
    - d5e43ebf ui: create component to add public key
    - 024a9389 pkg: add common code from validation function inside it own function
    - 61a82be1 ui: create component to add firewall rule in namespace
    - 3141ca74 ui: refactor the component to only support user edit in namespace
    - f92731ca ui: remove v-if in fragment
    - cfc0d71e ui: change color of buttons on firewall and public when disabled
    - 50440cea ui: create component to add member in namespace
    - b0d48ac5 openapi: add shared dependencies to index.html
    - 49300a69 docker: mount /openapi/spec instead of whole /openapi
    - 5b5f1497 openapi: add monitoring for change in spec directory on container
    - d36d949d openapi: rewrite server and documentation provide
    - c05fcf14 openapi: improve message to auth and info section
    - 1824eee9 openapi: add example to unauthorized response
    - f7875c90 openapi: change namespace param name from id to tenant
    - cc6ff4c6 openapi: update design from index.html
    - 8833e158 ui: refator member delete component
    - 339d9092 ui: fix console warnings

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>