### PR TITLE
shellhub-agent: Update version 0.22.0 -> 0.25.1

### DIFF
--- a/recipes-core/shellhub/shellhub-agent_0.25.1.bb
+++ b/recipes-core/shellhub/shellhub-agent_0.25.1.bb
@@ -13,7 +13,7 @@ SRC_URI = " \
     file://shellhub-agent.wrapper.in \
 "
 
-SRCREV = "eb710a0eaa04469b782b2f2534071d07fbdff3d3"
+SRCREV = "093900eb83c2a9f6dd5894964b06dc734bdd8d3e"
 
 inherit go systemd update-rc.d
 


### PR DESCRIPTION
Update shellhub-agent to the latest upstream release v0.25.1 (SRCREV matches the v0.25.1 tag). This brings origin/master up to the fully-updated state already used as the base of the wrynose branch.