### PR TITLE
shellhub-agent: Update version 0.25.1 -> 0.26.0

### DIFF
--- a/recipes-core/shellhub/shellhub-agent_0.26.0.bb
+++ b/recipes-core/shellhub/shellhub-agent_0.26.0.bb
@@ -17,7 +17,7 @@ SRC_URI = "\
     file://shellhub-agent.wrapper.in \
 "
 
-SRCREV = "093900eb83c2a9f6dd5894964b06dc734bdd8d3e"
+SRCREV = "34c91084a44f7a863c130e99b194e724de83a149"
 
 inherit go systemd update-rc.d
 


### PR DESCRIPTION
Backport of the v0.26.0 agent bump to wrynose (cherry-pick of 50c315a on master).

Bump the ShellHub agent to the v0.26.0 upstream release, updating SRCREV to the commit tagged v0.26.0. The AgentVersion ldflag tracks ${PV} automatically and the LICENSE.md checksum is unchanged.

Tested by cross-compiling for qemuarm (`bitbake shellhub-agent -c compile` succeeds).