### PR TITLE
shellhub-agent: Update version 0.22.0 -> 0.26.0

### DIFF
--- a/recipes-core/shellhub/shellhub-agent_0.26.0.bb
+++ b/recipes-core/shellhub/shellhub-agent_0.26.0.bb
@@ -13,7 +13,7 @@ SRC_URI = " \
     file://shellhub-agent.wrapper.in \
 "
 
-SRCREV="eb710a0eaa04469b782b2f2534071d07fbdff3d3"
+SRCREV="34c91084a44f7a863c130e99b194e724de83a149"
 
 inherit go systemd update-rc.d
 


### PR DESCRIPTION
Bump the ShellHub agent to the v0.26.0 upstream release on scarthgap (0.22.0 -> 0.26.0), updating SRCREV to the commit tagged v0.26.0. LICENSE.md checksum is unchanged.

This is a minimal version bump only — it deliberately does **not** import the master-era recipe modernisations (metadata additions, `${WORKDIR}` -> `${UNPACKDIR}` migration, oelint fixes), which are not appropriate for scarthgap's BitBake.

⚠️ **Needs a build check on a scarthgap tree before merge.** v0.26.0 declares `go 1.25.8` in go.mod and therefore requires a Go toolchain >= 1.25.8. scarthgap's default Go is older, so this may fail to compile unless the Go provider is new enough. I could not compile-verify it here (my build environment is master, not scarthgap).