### PR TITLE
conf/layer.conf: Export GOPROXY explicitly

### DIFF
--- a/compat/dunfell/conf/layer.conf
+++ b/compat/dunfell/conf/layer.conf
@@ -5,6 +5,7 @@ BBFILES += "${LAYERDIR}/compat/${LAYERSERIES_CORENAMES}/*/*/*.bb \
 
 # The shellhub-agent requires Go 1.20+
 GOVERSION = "1.26%"
-export GOPROXY ??= "https://proxy.golang.org,direct"
+GOPROXY ??= "https://proxy.golang.org,direct"
+GOPROXY[export] = "1"
 PREFERRED_PROVIDER_go-native = "go-binary-native"
 PREFERRED_VERSION_go-binary-native = "${GOVERSION}"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -19,7 +19,8 @@ SIGGEN_EXCLUDERECIPES_ABISAFE += "shellhub-agent-config"
 
 # The shellhub-agent requires Go 1.20+.
 GOVERSION = "1.26%"
-export GOPROXY ??= "https://proxy.golang.org,direct"
+GOPROXY ??= "https://proxy.golang.org,direct"
+GOPROXY[export] = "1"
 PREFERRED_PROVIDER_go-native = "go-binary-native"
 PREFERRED_VERSION_go-binary-native = "${GOVERSION}"
 PREFERRED_VERSION_go-native = "${GOVERSION}"

--- a/recipes-core/shellhub/shellhub-agent_0.26.0.bb
+++ b/recipes-core/shellhub/shellhub-agent_0.26.0.bb
@@ -13,7 +13,7 @@ SRC_URI = " \
     file://shellhub-agent.wrapper.in \
 "
 
-SRCREV="eb710a0eaa04469b782b2f2534071d07fbdff3d3"
+SRCREV="34c91084a44f7a863c130e99b194e724de83a149"
 
 inherit go systemd update-rc.d
 


### PR DESCRIPTION
Use BitBake's export varflag for GOPROXY instead of the inline
  "export GOPROXY ??=" form.

  The inline form breaks setup-environment's layer.conf parser with:

    Syntax error (operator): export GOPROXY ??= "https://proxy.golang.org,direct"

  This keeps the weak GOPROXY default while still exporting it to Go task
  environments.

  Tested with:
  - source setup-environment build
  - bitbake -p
