### PR TITLE
Allow device registration by install key

### DIFF
--- a/classes/shellhub-rootfs-postcommand.bbclass
+++ b/classes/shellhub-rootfs-postcommand.bbclass
@@ -1,27 +1,70 @@
 # nooelint: oelint.bbclass.underscores oelint.file.inlinesuppress_na  no EXPORT_FUNCTIONS here, so the dash is harmless
-# Allow overriding of ShellHub Tenant ID
+# Allow overriding of the ShellHub registration credential
 #
-# Required variable:
+# Required variable, exactly one of:
+#
+#  SHELLHUB_ROOTFS_INSTALL_KEY
+#
+#  Overrides the registration credential with a namespace install key. This is
+#  the supported path for a fleet.
 #
 #  SHELLHUB_ROOTFS_TENANT_ID
 #
-#  The SHELLHUB_ROOTFS_TENANT_ID allow for override of existing ShellHub Tenant
-#  ID during rootfs generation.
+#  Overrides the registration credential with a tenant ID. Deprecated, kept
+#  only for existing integrations.
 #
 # Copyright 2021 (C) O.S. Systems Software LTDA.
 
-# Override the TENANT_ID from existing ShellHub configuration file.
-ROOTFS_POSTPROCESS_COMMAND += "shellhub_override_tenant_id;"
-shellhub_override_tenant_id[doc] = "Override the ShellHub TENANT_ID in the rootfs config from SHELLHUB_ROOTFS_TENANT_ID."
-shellhub_override_tenant_id () {
+# "undefined" is the unset sentinel for both, matching shellhub-agent-config.
+SHELLHUB_ROOTFS_INSTALL_KEY ??= "undefined"
+SHELLHUB_ROOTFS_TENANT_ID ??= "undefined"
+
+# Override the registration credential in an existing ShellHub configuration file.
+ROOTFS_POSTPROCESS_COMMAND += "shellhub_override_registration;"
+shellhub_override_registration[doc] = "Override the ShellHub registration credential in the rootfs config from SHELLHUB_ROOTFS_INSTALL_KEY or SHELLHUB_ROOTFS_TENANT_ID."
+shellhub_override_registration () {
     if [ ! -e "${IMAGE_ROOTFS}${sysconfdir}/default/shellhub-agent" ]; then
         bbfatal "'${sysconfdir}/default/shellhub-agent' doesn't exist."
     fi
 
-    if [ -z "${SHELLHUB_ROOTFS_TENANT_ID}" ]; then
-        bbfatal "SHELLHUB_ROOTFS_TENANT_ID variable is undefined."
+    # An explicitly emptied value counts as unset alongside the sentinel, so
+    # clearing an inherited SHELLHUB_ROOTFS_TENANT_ID is a way to move to an
+    # install key.
+    install_key="${SHELLHUB_ROOTFS_INSTALL_KEY}"
+    if [ "$install_key" = "undefined" ]; then
+        install_key=""
     fi
 
-    sed -i 's%^TENANT_ID=.*%TENANT_ID="${SHELLHUB_ROOTFS_TENANT_ID}"%g' \
+    tenant_id="${SHELLHUB_ROOTFS_TENANT_ID}"
+    if [ "$tenant_id" = "undefined" ]; then
+        tenant_id=""
+    fi
+
+    if [ -n "$install_key" ] && [ -n "$tenant_id" ]; then
+        bbfatal "SHELLHUB_ROOTFS_INSTALL_KEY and SHELLHUB_ROOTFS_TENANT_ID are mutually exclusive; set only one of them."
+    fi
+
+    if [ -n "$install_key" ]; then
+        credential="INSTALL_KEY=\"$install_key\""
+    elif [ -n "$tenant_id" ]; then
+        credential="TENANT_ID=\"$tenant_id\""
+    else
+        bbfatal "Set SHELLHUB_ROOTFS_INSTALL_KEY to override the registration credential. SHELLHUB_ROOTFS_TENANT_ID is also accepted, but registering by tenant ID is deprecated."
+    fi
+
+    # The config carries exactly one credential line, so rewriting either one
+    # covers swapping a tenant-built image over to an install key.
+    if ! grep -qE '^(INSTALL_KEY|TENANT_ID)=' ${IMAGE_ROOTFS}${sysconfdir}/default/shellhub-agent; then
+        bbfatal "'${sysconfdir}/default/shellhub-agent' carries no registration credential to override."
+    fi
+
+    # Rewritten with awk rather than sed so the credential is substituted
+    # literally; a '&' or a '%' in it would otherwise be taken as sed syntax.
+    credential="$credential" awk '
+        /^(INSTALL_KEY|TENANT_ID)=/ { print ENVIRON["credential"]; next }
+        { print }
+    ' ${IMAGE_ROOTFS}${sysconfdir}/default/shellhub-agent > ${WORKDIR}/shellhub-agent.override
+    install -m 0644 ${WORKDIR}/shellhub-agent.override \
         ${IMAGE_ROOTFS}${sysconfdir}/default/shellhub-agent
+    rm -f ${WORKDIR}/shellhub-agent.override
 }

--- a/recipes-core/shellhub/shellhub-agent-config_1.0.bb
+++ b/recipes-core/shellhub/shellhub-agent-config_1.0.bb
@@ -1,6 +1,6 @@
 # nooelint: oelint.var.mandatoryvar.SRC_URI oelint.var.suggestedvar.CVE_PRODUCT  config recipe: it generates its config inline (no SRC_URI) and ships no code to CVE-track
 SUMMARY = "ShellHub Configuration"
-DESCRIPTION = "Generates the global ShellHub agent configuration (server address, private key path and tenant ID)."
+DESCRIPTION = "Generates the global ShellHub agent configuration (server address, private key path and the registration credential, either an install key or a tenant ID)."
 HOMEPAGE = "https://shellhub.io"
 BUGTRACKER = "https://github.com/shellhub-io/shellhub/issues"
 SECTION = "console/network"
@@ -14,19 +14,55 @@ do_configure[noexec] = "1"
 
 SHELLHUB_SERVER_ADDRESS ??= "https://cloud.shellhub.io"
 SHELLHUB_PRIVATE_KEY ??= "${sysconfdir}/shellhub-agent.key"
+
+# Registration credential. Set exactly one of the two.
+#
+# SHELLHUB_INSTALL_KEY registers the device through a namespace install key,
+# which applies the key's tags and acceptance mode to the whole batch. This is
+# the supported path for a fleet.
+#
+# SHELLHUB_TENANT_ID registers through the namespace's legacy source, which
+# seeds devices as pending for manual acceptance. It is deprecated and kept
+# only for existing integrations.
+SHELLHUB_INSTALL_KEY ??= "undefined"
 SHELLHUB_TENANT_ID ??= "undefined"
 
 # nooelint: oelint.task.noanonpython  required to SkipRecipe at parse time
 python () {
-    if d.getVar("SHELLHUB_TENANT_ID", False) == "undefined":
-        raise bb.parse.SkipRecipe("To enable ShellHub support, the 'SHELLHUB_TENANT_ID' variable must be set.")
+    # "undefined" is the unset sentinel for both credentials. An explicitly
+    # emptied value counts as unset too, so clearing an inherited
+    # SHELLHUB_TENANT_ID is a way to move to an install key.
+    install_key = d.getVar("SHELLHUB_INSTALL_KEY")
+    tenant_id = d.getVar("SHELLHUB_TENANT_ID")
+
+    if install_key in ("", "undefined"):
+        install_key = ""
+
+    if tenant_id in ("", "undefined"):
+        tenant_id = ""
+
+    if install_key and tenant_id:
+        bb.fatal("'SHELLHUB_INSTALL_KEY' and 'SHELLHUB_TENANT_ID' are mutually exclusive; set only one of them.")
+
+    if not install_key and not tenant_id:
+        raise bb.parse.SkipRecipe("To enable ShellHub support, set 'SHELLHUB_INSTALL_KEY' to a namespace install key. "
+                                  "'SHELLHUB_TENANT_ID' is also accepted, but registering by tenant ID is deprecated.")
+
+    # Store the resolved values back so do_compile only has to test for
+    # emptiness rather than repeat the sentinel handling in shell.
+    d.setVar("SHELLHUB_INSTALL_KEY", install_key)
+    d.setVar("SHELLHUB_TENANT_ID", tenant_id)
 }
 
 do_compile () {
     {
         echo "SERVER_ADDRESS=\"${SHELLHUB_SERVER_ADDRESS}\""
         echo "PRIVATE_KEY=\"${SHELLHUB_PRIVATE_KEY}\""
-        echo "TENANT_ID=\"${SHELLHUB_TENANT_ID}\""
+        if [ -n "${SHELLHUB_INSTALL_KEY}" ]; then
+            echo "INSTALL_KEY=\"${SHELLHUB_INSTALL_KEY}\""
+        else
+            echo "TENANT_ID=\"${SHELLHUB_TENANT_ID}\""
+        fi
     } > shellhub-agent.default
 }
 

--- a/recipes-core/shellhub/shellhub-agent/shellhub-agent.initd
+++ b/recipes-core/shellhub/shellhub-agent/shellhub-agent.initd
@@ -37,6 +37,7 @@ export LOGFILE
 # shellhub-agent.start
 export SERVER_ADDRESS
 export PRIVATE_KEY
+export INSTALL_KEY
 export TENANT_ID
 
 do_start()


### PR DESCRIPTION
`meta-shellhub` could only register a device by tenant ID, so every unit built from a Yocto image arrived through the namespace's legacy source. That source is seeded in `manual` mode, which turns a production run into a queue of pending devices for somebody to accept by hand. An install key is what avoids that, and it carries tags, so an access policy can cover the batch before anybody opens the console.

The agent already reads it. `InstallKey` is `env:"INSTALL_KEY"` and the config is parsed with `MultiLookuper(PrefixLookuper("SHELLHUB_", …), OsLookuper())`, so an unprefixed `INSTALL_KEY=` in `/etc/default/shellhub-agent` is picked up. Only the layer was missing.

### shellhub-agent-config

`SHELLHUB_INSTALL_KEY` joins `SHELLHUB_TENANT_ID`, and the recipe emits `INSTALL_KEY=` into `/etc/default/shellhub-agent`. Exactly one credential line is written, so an install-key build never ships `TENANT_ID="undefined"`.

The two are mutually exclusive rather than a precedence pair, per the issue: setting both fails the build instead of silently picking one. The parse guard now accepts either, so an integrator setting an install key no longer has to invent a tenant to get past the check. Tenant-only registration stays for existing integrations, and the guard's message names the install key as the path for anything new.

### shellhub-rootfs-postcommand

Not in the issue's scope, but it fell out of the same change: the class only rewrote `TENANT_ID`, so an install-key image had no rootfs-time override at all. The sed matched nothing and the class reported success. `SHELLHUB_ROOTFS_INSTALL_KEY` is the counterpart, with the same mutual exclusion, and the sed now matches either credential line so a tenant-built image can be swapped over to an install key. The function is renamed to `shellhub_override_registration` since it no longer only touches the tenant.

Two latent bugs came along with it. Neither variable had a default, so bitbake left the literal `${SHELLHUB_ROOTFS_TENANT_ID}` in the generated task script, the `[ -z ]` guard never fired, and the unexpanded text was written into the rootfs config. And a config with no credential line at all was seded to no effect and reported as done. Both now fail loudly.

### Testing

Built `shellhub-agent-config` for qemuarm in all four configurations: install key only writes `INSTALL_KEY=`, tenant only writes `TENANT_ID=` as before, both fails parsing with the mutual-exclusion message, neither skips the recipe with a message pointing at `SHELLHUB_INSTALL_KEY`.

For the class, extracted the expanded function from `bitbake -e` for each combination and ran it against fixture configs built both ways. Overriding by install key or by tenant rewrites the line whichever credential the image shipped. Setting both, setting neither, a config with no credential line, and a missing config each fail with their own message.

`oelint-adv` is clean over the layer.

### Note

The Yocto and Buildroot documentation pages describe `SHELLHUB_INSTALL_KEY` as available and should not be published before this lands. Buildroot needs no change; it configures through a rootfs overlay the integrator writes, so swapping `TENANT_ID` for `INSTALL_KEY` already works there.

Implements shellhub-io/team#228